### PR TITLE
fix(types): Use inline definition of ActionCreator to make typescript happy with union types as payloads

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,30 +2,43 @@ import {createHelpers} from "./index"
 
 interface State {
   value: number
+  maybeValue: number | null
 }
 
 interface Actions {
   addValue: number
+  setValue: number | null
 }
 
-const initialState: State = {value: 1}
+const initialState: State = {value: 1, maybeValue: null}
 
 const helpers = createHelpers<State, Actions>("Foo", initialState, {
   addValue: (state, payload) => {
     return {value: state.value + payload}
   },
+  setValue: (state, payload) => {
+    return {maybeValue: payload}
+  },
 })
 
 test("reducer", () => {
-  const newState = helpers.reducer(
+  let newState = helpers.reducer(
     undefined,
     helpers.actionCreators.addValue(100),
   )
   expect(newState.value).toBe(101)
+
+  newState = helpers.reducer(
+    undefined,
+    helpers.actionCreators.setValue(12),
+  )
+  expect(newState.maybeValue).toBe(12)
+
 })
 
 test("action type", () => {
-  expect(helpers.actionTypes.addValue).toBe("[Foo] addValue")
+  expect(helpers.actionTypes.addValue).toBe("[Foo] addValue"),
+  expect(helpers.actionTypes.setValue).toBe("[Foo] setValue")
 })
 
 test("action creator", () => {
@@ -33,4 +46,13 @@ test("action creator", () => {
     type: "[Foo] addValue",
     payload: 100,
   })
+  expect(helpers.actionCreators.setValue(12)).toEqual({
+    type: "[Foo] setValue",
+    payload: 12,
+  })
+  expect(helpers.actionCreators.setValue(null)).toEqual({
+    type: "[Foo] setValue",
+    payload: null,
+  })
+
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export type ActionCreator<TPayload> = TPayload extends void
   : (payload: TPayload) => Action<TPayload>
 
 export type ActionCreators<TActions> = {
-  [key in keyof TActions]: ActionCreator<TActions[key]>
+  [key in keyof TActions]: TActions[key] extends void ? () => Action<TActions[key]> : (payload: TActions[key]) => Action<TActions[key]>
 }
 
 export type ActionTypes<TActions> = {[key in keyof TActions]: string}


### PR DESCRIPTION
There seem to be issues with union type payloads with how the ActionCreator types are generated or try to be figured out by typescript, related to this issue:

https://github.com/Microsoft/TypeScript/issues/7294

Inlining the `ActionCreator` definition seems to fix this.

This is easy to test out by making a union type in actions:

```
interface Actions {
   someThing: number | string
}
```

This is a much more trivial use case than what I have, I effectively have a `Result` type for asynchronous results that can be a union of Err | Some | None | Loading with data attached, but the example above will trigger the same type error.
