### PR TITLE
Fix minor typo in README code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ export function reducer(state = initialState, action: CounterActionsUnion): Stat
 
 const actionCreators = {
   increment: () => new Increment(),
-  setValue: (payload: number) => new setValue(payload),
+  setValue: (payload: number) => new SetValue(payload),
 }
 ```
 ## ts-reducer-creator


### PR DESCRIPTION
Simply fixes capitalization on one of the `SetValue` action creation.